### PR TITLE
Fix typos and add more comments to evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,26 @@ Lemur works as a cross-platform compiler. It parses NF chains from a user-level 
 $ git clone https://github.com/USC-NSL/Lemur.git
 ```
 
+(2) Check the Python version
+Lemur is tested with Python 2.7.12.<br>
+Please make sure you have the correct Python + Pip version.<br>
+We recommend using pyenv (https://github.com/pyenv/pyenv) to manage your Python local env.<br>
+
 (2) Install dependencies<br>
 ``` bash
 $ ./install_deps.sh
 ```
 
+Required dependencies:<br>
+* Numpy 1.15.4
+* paramiko 1.16.0
+* Pexpect 4.6.0
+* termcolor 1.1.0
+
 (3) Get Gurobi License<br>
 Please follow the instructions in /src folder to get your Gurobi license
+
+Note: according to some Lemur users, Lemur compiler may not work properly under academic licence outside the US.
 
 ## Configuring Lemur
 (1) Visit the `src` directory and define your service chain configuration file in the `user_level_example` directory<br>

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ $ git clone https://github.com/USC-NSL/Lemur.git
 ```
 
 (2) Check the Python version
-Lemur is tested with Python 2.7.12.<br>
-Please make sure you have the correct Python + Pip version.<br>
+Lemur is tested with Python 2.7.12 + pip 20.2.4.<br>
+Please make sure you have the correct Python + pip version.<br>
 We recommend using pyenv (https://github.com/pyenv/pyenv) to manage your Python local env.<br>
 
 (2) Install dependencies<br>

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -8,8 +8,9 @@ sudo apt-get update
 sudo apt-get install default-jdk
 
 # Install pip
-sudo apt-get install python-pip
+#sudo apt-get install python-pip
 #sudo pip install --upgrade pip
+sudo python -m easy_install --upgrade pyOpenSSL
 
 # Install ANTLR
 cd ./env/antlr
@@ -23,6 +24,6 @@ sudo cpan Graph:Easy
 
 # Install python lib
 pip install paramiko --user
-pip isntall Pexpect --user
+pip install Pexpect --user
 pip install numpy --user
 pip install termcolor --user

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -7,9 +7,18 @@ echo "$THIS_DIR"
 sudo apt-get update
 sudo apt-get install default-jdk
 
+#
 # Install pip
-#sudo apt-get install python-pip
-#sudo pip install --upgrade pip
+# Note: if you do not have Python + pip installed, first install
+# them with pyenv. See https://github.com/pyenv/pyenv for more
+# details.
+# 
+# git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+# echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
+# echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
+# echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
+#
+
 sudo python -m easy_install --upgrade pyOpenSSL
 
 # Install ANTLR

--- a/src/README.md
+++ b/src/README.md
@@ -15,5 +15,4 @@ sudo python setup install
 
 (3) Get [Gurobi license](https://www.gurobi.com/downloads/end-user-license-agreement-academic/) and install license
 
-
-
+Note: according to some Lemur users, Lemur compiler may not work properly under academic licence outside the US.


### PR DESCRIPTION
1. Add a note on gurobi license
2. Document python + pip versions and additional dependencies
3. Fix typo in install_deps.sh
4. Fix warning for install_deps.sh for the CryptographyDeprecationWarning